### PR TITLE
商品の削除機能を追加

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,10 +16,11 @@
 @import "module/side-bar";           //サイドバー
 // ---------------------------------------------------------
 //＊＊＊＊ 商品関連 ＊＊＊＊
-@import "items/index";    // トップページのビュー
-@import "items/new";      // 商品出品ページのビュー
+@import "items/index";               // トップページのビュー
+@import "items/new";                 // 商品出品ページのビュー
 @import "items/show";                //商品詳細ページ
-@import "items/purchase"; // 商品購入確認ページのビュー
+@import "items/purchase";            // 商品購入確認ページのビュー
+@import "items/destroy";            // 商品の削除完了ページのビュー
 // ---------------------------------------------------------
 //＊＊＊＊ ユーザー関連 ＊＊＊＊
 @import "users/registrations";

--- a/app/assets/stylesheets/items/_destroy.scss
+++ b/app/assets/stylesheets/items/_destroy.scss
@@ -1,0 +1,34 @@
+// users/showのscssファイルを流用している
+.info{
+  .info-box{
+    &__delete--notice{
+      font-weight: bold;
+      text-align: center;
+      height: 74px;
+      width: 100%;
+      background-color: #fff;
+      border-top: 2px solid #3CCACE;
+      display: inline-block;
+      line-height: 74px;
+    } 
+  }
+  .info-content{
+    &__list{
+      img{}
+      &__body{
+        &__text--destroy{
+          float: right;
+          color: red;
+          font-weight: bold;
+        }
+        &__time{
+          .clock-icon{}
+          &__hour{}
+        }
+      }
+      .nav_item{
+        i{}
+      }
+    }
+  }
+}

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -27,6 +27,9 @@ class ItemsController < ApplicationController
   end
 
   def destroy
+    @item = Item.find(params[:id])
+    @name = @item.name
+    @item.destroy
   end
 
   def purchase

--- a/app/views/items/destroy.html.haml
+++ b/app/views/items/destroy.html.haml
@@ -1,0 +1,35 @@
+-# ユーザーマイページのビューを流用
+.nav-bar
+  %ol
+    %li.nav-var-merukari
+      =link_to "#", class: "nav-var-merukari-text" do
+        FURIMA
+    %i.fas.fa-chevron-right
+    %li.nav-ber-active
+      マイページ
+
+.mypagewrapper
+  =render 'module/side-bar'
+
+  .info
+    .info-box
+      .info-box__delete--notice
+        商品削除のお知らせ
+    .info-content
+      .info-content__list
+        = image_tag ("small-logo.png")
+        .info-content__list__body
+          .info-content__list__body__text--destroy
+            = "#{@name}の出品を取りやめました。"
+          .info-content__list__body__time
+            = link_to "#", class: "clock-icon" do
+              %i.far.fa-clock
+            .info-content__list__body__time__hour
+              = Time.zone.now.strftime("%Y年%m月%d日 %H時%M分")
+        = link_to "#", class: "nav_item"  do
+          %i.fas.fa-chevron-right
+
+    .info-list
+      = link_to root_path, class: "list_box__list__text" do 
+        商品一覧に戻る
+  

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -62,7 +62,7 @@
       - if user_signed_in? == true then
         - if current_user.id == @item.user.id then
           = button_to "商品情報の編集", {controller: 'items', action: 'edit',id: @item.id}, {method: :patch, class: 'succession_btn', id: "edit"}
-          = button_to "出品を取りやめる", {controller: 'items', action: 'destroy',id: @item.id}, {method: :delete, class: 'succession_btn', id: "destroy"}
+          = button_to "出品を取りやめる", {controller: 'items', action: 'destroy',id: @item.id}, {method: :delete, class: 'succession_btn', id: "destroy", data: {confirm: "本当に削除しますか？"}}
         - else
           %label.button_to
             %button{type: "sumit", class: "succession_btn"} 購入画面に進む

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -2,7 +2,7 @@
   %ol
     %li.nav-var-merukari
       =link_to "#", class: "nav-var-merukari-text" do
-        メルカリ
+        FURIMA
     %i.fas.fa-chevron-right
     %li.nav-ber-active
       マイページ

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,5 +11,7 @@ module FurimaApp
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+
+    config.time_zone = "Tokyo"
   end
 end


### PR DESCRIPTION
## why
出品した商品を削除する機能を取り付けため
## what
・商品を取りやめるボタンを押した時に、データベースから商品を削除するようにコントローラーを設定
（削除ボタンを押した時に、削除確認機能rails-ujsの機能を使って実装）
・商品を削除完了画面を作成（HTML・CSS）

### 実際の操作画面
＜出品の取りやめ＞
https://gyazo.com/afd3e63cc5949a62689e7d7284dc0de8
＜商品一覧から化粧水が消えていることを確認＞
https://gyazo.com/1a5f61af62c930f834232d17cc2bb857

<ターミナルでitemテーブルとそれに紐ずくitem_imageテーブルのレコードも一緒に削除されている>
https://gyazo.com/d37035d8288532f60fca9d9d2ecdf1e3